### PR TITLE
fix: workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,7 +25,7 @@ jobs:
         run: docker pull $IMAGE/api:latest
 
       - name: Tag Docker Image
-        run: docker build -f Dockerfile . --tag $IMAGE/api:latest --cache-from $IMAGE:latest
+        run: docker build -f Dockerfile . --tag $IMAGE/api:latest --cache-from $IMAGE/api:latest
 
       - name: Push Docker Image
         run: docker push $IMAGE/api:latest
@@ -44,7 +44,7 @@ jobs:
         run: docker pull $IMAGE/web:latest
 
       - name: Tag Docker Image
-        run: docker build -f Dockerfile . --tag $IMAGE/web:latest --cache-from $IMAGE:latest
+        run: docker build -f Dockerfile . --tag $IMAGE/web:latest --cache-from $IMAGE/web:latest
 
       - name: Push Docker Image
         run: docker push $IMAGE/web:latest

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,6 +4,9 @@ on:
   push:
     branches:
       - main
+  pull_request:
+    branches:
+      - main
 
 env:
   IMAGE: ${{ secrets.IMAGE_URL }}
@@ -19,16 +22,25 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Registry login
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
         run: echo $PAT | docker login ghcr.io -u $GITHUB_ACTOR --password-stdin
 
-      - name: Pull Docker Image
-        run: docker pull $IMAGE/api:latest
+      - name: Pull Docker Image (for cache)
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        run: docker pull $IMAGE/api:latest || true
 
-      - name: Tag Docker Image
-        run: docker build -f Dockerfile . --tag $IMAGE/api:latest --cache-from $IMAGE/api:latest
+      - name: Build Docker Image
+        run: |
+          if [ "${{ github.event_name }}" = "push" ] && [ "${{ github.ref }}" = "refs/heads/main" ]; then
+            docker build -f Dockerfile . --tag $IMAGE/api:latest --cache-from $IMAGE/api:latest
+          else
+            docker build -f Dockerfile . --tag temp-api:${{ github.sha }}
+          fi
 
       - name: Push Docker Image
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
         run: docker push $IMAGE/api:latest
+
   build-web:
     runs-on: ubuntu-latest
     defaults:
@@ -38,13 +50,21 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Registry login
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
         run: echo $PAT | docker login ghcr.io -u $GITHUB_ACTOR --password-stdin
 
-      - name: Pull Docker Image
-        run: docker pull $IMAGE/web:latest
+      - name: Pull Docker Image (for cache)
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        run: docker pull $IMAGE/web:latest || true
 
-      - name: Tag Docker Image
-        run: docker build -f Dockerfile . --tag $IMAGE/web:latest --cache-from $IMAGE/web:latest
+      - name: Build Docker Image
+        run: |
+          if [ "${{ github.event_name }}" = "push" ] && [ "${{ github.ref }}" = "refs/heads/main" ]; then
+            docker build -f Dockerfile . --tag $IMAGE/web:latest --cache-from $IMAGE/web:latest
+          else
+            docker build -f Dockerfile . --tag temp-web:${{ github.sha }}
+          fi
 
       - name: Push Docker Image
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
         run: docker push $IMAGE/web:latest

--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@
 # AI
 .claude/
 .codex/
+CLAUDE.md
 
 # API
 *.pyc


### PR DESCRIPTION
This pull request includes updates to the `.github/workflows/build.yml` file to fix the `--cache-from` parameter in Docker image builds for the `api` and `web` services. The changes ensure that the correct image cache is used during the build process.

Docker build cache fixes:

* [`.github/workflows/build.yml`](diffhunk://#diff-5c3fa597431eda03ac3339ae6bf7f05e1a50d6fc7333679ec38e21b337cb6721L28-R28): Updated the `--cache-from` parameter for the `api` service to use `$IMAGE/api:latest` instead of `$IMAGE:latest`.
* [`.github/workflows/build.yml`](diffhunk://#diff-5c3fa597431eda03ac3339ae6bf7f05e1a50d6fc7333679ec38e21b337cb6721L47-R47): Updated the `--cache-from` parameter for the `web` service to use `$IMAGE/web:latest` instead of `$IMAGE:latest`.