### PR TITLE
Fix npm optional dependency issue for web

### DIFF
--- a/web/Dockerfile.dev
+++ b/web/Dockerfile.dev
@@ -1,7 +1,14 @@
-FROM node:24
+# Use Node 18 to avoid npm optional dependency issues on arm64
+FROM node:18
 
 # Set working directory
 WORKDIR /var/www
+
+COPY package*.json ./
+# Install dependencies without optional packages to avoid rollup arm64 issues
+RUN apt-get update \
+    && npm i -g @angular/cli \
+    && npm install --no-optional
 
 COPY . .
 
@@ -13,11 +20,6 @@ ENV NODE_EXTRA_CA_CERTS=/etc/ssl/certs/ca-certificates.crt \
     CURL_CA_BUNDLE=/etc/ssl/certs/ca-certificates.crt \
     SSL_CERT_FILE=/etc/ssl/certs/ca-certificates.crt \
     SSL_CERT_DIR=/etc/ssl/certs/
-
-# Copy package files and install dependencies
-RUN apt-get update \
-    && npm i -g @angular/cli \
-    && npm i
 
 # Expose the Angular dev server port
 EXPOSE 4200


### PR DESCRIPTION
## Summary
- switch web Docker dev image to Node 18
- install dependencies without optional packages to avoid rollup arm64 issue

## Testing
- `npm test --prefix web` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_b_683f83a77d24832eb47704a4ec190485