### PR TITLE
update makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,9 +26,17 @@ up-prod:
 stop:
 	docker compose stop
 
+# target: stop-prod - Stop the production docker container.
+stop-prod:
+	docker compose -f compose.production.yml stop
+
 # target: down - Stop the docker container.
 down:
 	docker compose down -v --remove-orphans
+
+# target: down-prod - Stop the production docker container.
+down-prod:
+	docker compose -f compose.production.yml down -v --remove-orphans
 
 # target: deploy - deploy to resdeeds server
 deploy:


### PR DESCRIPTION
This pull request introduces new Makefile targets to manage production Docker containers. These changes enhance the flexibility of the development workflow by providing dedicated commands for stopping and removing production containers.

### New Makefile targets for production:

* [`stop-prod`](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52R29-R40): Added a target to stop the production Docker container using the `compose.production.yml` configuration file.
* [`down-prod`](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52R29-R40): Added a target to stop and remove the production Docker container, including volumes and orphan containers, using the `compose.production.yml` configuration file.