### PR TITLE
fix: release steps

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,7 +33,7 @@ jobs:
     
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v4.2.2
 
       - name: Install pnpm
         uses: pnpm/action-setup@v4
@@ -43,7 +43,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '20.x'
           cache: 'pnpm'
 
       - name: Install dependencies
@@ -61,11 +61,12 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Upload artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v4.6.2
         with:
           name: resdeeds-${{ matrix.platform }}
           path: ${{ matrix.artifact-pattern }}
           retention-days: 30
+          compression-level: 6
 
   release:
     needs: build
@@ -74,10 +75,10 @@ jobs:
     
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v4.2.2
 
       - name: Download all artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v4.3.0
         with:
           path: artifacts
 
@@ -85,24 +86,19 @@ jobs:
         run: ls -la artifacts/
 
       - name: Create Release
-        id: create_release
-        uses: actions/create-release@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          tag_name: ${{ github.ref_name }}
-          release_name: ResDEEDS ${{ github.ref_name }}
-          body: |
-            ## ResDEEDS ${{ github.ref_name }}
+        run: |
+          gh release create ${{ github.ref_name }} \
+            --title "ResDEEDS ${{ github.ref_name }}" \
+            --notes "## ResDEEDS ${{ github.ref_name }}
             
             ### Downloads
-            - **macOS**: Download the `.dmg` file for macOS installation
-            - **Windows**: Download the `.exe` file for Windows installation
+            - **macOS**: Download the \`.dmg\` file for macOS installation
+            - **Windows**: Download the \`.exe\` file for Windows installation
             
             ### Changes
-            See [CHANGELOG.md](https://github.com/${{ github.repository }}/blob/main/CHANGELOG.md) for full details.
-          draft: false
-          prerelease: false
+            See [CHANGELOG.md](https://github.com/${{ github.repository }}/blob/main/CHANGELOG.md) for full details."
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Find and upload macOS artifacts
         run: |


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow configuration in `.github/workflows/release.yml` to use more specific action versions, improve artifact handling, and switch to using the GitHub CLI for releases. These changes enhance workflow reliability, security, and maintainability.

**Workflow action version updates:**

* Updated the versions of key GitHub Actions (`actions/checkout`, `actions/upload-artifact`, and `actions/download-artifact`) to use explicit patch versions, improving security and stability. [[1]](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L36-R36) [[2]](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L64-R69) [[3]](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L77-R101)

**Node.js setup improvement:**

* Changed the Node.js version specification from `'20'` to `'20.x'` in `actions/setup-node` to ensure the latest compatible minor/patch release is used.

**Artifact handling enhancements:**

* Added the `compression-level: 6` option to the artifact upload step for better storage efficiency.

**Release creation modernization:**

* Replaced the `actions/create-release` action with a direct call to the GitHub CLI (`gh release create`), providing more flexibility and control over release notes formatting and release creation.