### PR TITLE
update github token

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,9 +15,6 @@ env:
   ELECTRON_CACHE: ~/.cache/electron
   ELECTRON_BUILDER_CACHE: ~/.cache/electron-builder
 
-permissions:
-  contents: write
-
 jobs:
   build:
     strategy:
@@ -61,7 +58,7 @@ jobs:
       - name: Build application (${{ matrix.platform }})
         run: pnpm ${{ matrix.script }}
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.PAT }}
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v4.6.2
@@ -101,7 +98,7 @@ jobs:
             ### Changes
             See [CHANGELOG.md](https://github.com/${{ github.repository }}/blob/main/CHANGELOG.md) for full details."
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.PAT }}
 
       - name: Find and upload macOS artifacts
         run: |
@@ -121,7 +118,7 @@ jobs:
             echo "No ZIP file found"
           fi
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.PAT }}
 
       - name: Find and upload Windows artifacts
         run: |
@@ -133,4 +130,4 @@ jobs:
             echo "No EXE file found"
           fi
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.PAT }}


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow for releases by changing the authentication method from the default `GITHUB_TOKEN` to a custom personal access token (`PAT`). It also removes the explicit `permissions` block from the workflow configuration. These changes are likely aimed at providing finer control over permissions or enabling actions that require a broader scope than the default token allows.

**Authentication and permissions updates:**

* Replaced all instances of `GITHUB_TOKEN` with `PAT` in the workflow's environment variables for build, release, and artifact upload steps. [[1]](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L64-R61) [[2]](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L104-R101) [[3]](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L124-R121) [[4]](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L136-R133)
* Removed the `permissions` block (which previously set `contents: write`) from the workflow configuration.