### PR TITLE
fix: release dist location

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,11 +23,11 @@ jobs:
           - os: macos-latest
             platform: mac
             script: dist:mac
-            artifact-pattern: 'dist/*.{dmg,zip}'
+            artifact-pattern: 'dist/**/*'
           - os: windows-latest
             platform: win
             script: dist:win
-            artifact-pattern: 'dist/*.exe'
+            artifact-pattern: 'dist/**/*'
 
     runs-on: ${{ matrix.os }}
     

--- a/README.md
+++ b/README.md
@@ -80,6 +80,14 @@ pnpm dist:win     # Windows
 pnpm dist:linux   # Linux
 ```
 
+## Initiate a Release
+
+```bash
+git tag -a <version number> -m "Release version 1.0.0"
+
+git push origin <version number>
+```
+
 ## Usage
 
 ### Creating a Network


### PR DESCRIPTION
This pull request updates the release workflow and documentation to improve the release process. The most important changes are:

**Release Workflow Improvements**
* Broadened the artifact pattern in `.github/workflows/release.yml` for both macOS and Windows to include all files under the `dist` directory, ensuring all relevant build artifacts are uploaded.

**Documentation Updates**
* Added a new section to `README.md` with step-by-step instructions on how to initiate a release using Git tags and pushing them to the remote repository.