### PR TITLE
fix(ci): update artifact upload patterns to match actual dist structure

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,11 +23,14 @@ jobs:
           - os: macos-latest
             platform: mac
             script: dist:mac
-            artifact-pattern: 'dist/**/*'
+            artifact-pattern: |
+              dist/*.dmg
+              dist/*.zip
           - os: windows-latest
             platform: win
             script: dist:win
-            artifact-pattern: 'dist/**/*'
+            artifact-pattern: |
+              dist/*.exe
 
     runs-on: ${{ matrix.os }}
     


### PR DESCRIPTION
## Summary
Fixes the GitHub Actions warning: "No files were found with the provided path: dist/*.{dmg,zip}. No artifacts will be uploaded."

## Changes
- Updated artifact upload patterns in the release workflow to match actual dist structure
- Changed from generic `dist/**/*` to specific patterns:
  - **macOS**: `dist/*.dmg`, `dist/*.zip`
  - **Windows**: `dist/*.exe`

## Test plan
- [x] Verified local dist/ structure contains these file patterns
- [ ] Test workflow runs without artifact upload warnings
- [ ] Confirm artifacts are properly uploaded to GitHub Actions

## Context
The electron-builder generates files with specific naming patterns in the dist/ directory. Using targeted patterns ensures reliable artifact collection and eliminates the warning about missing files.