### PR TITLE
fix: downloadable installer

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,11 +15,35 @@ ResDEEDS is a desktop application for designing PyPSA (Python for Power System A
 
 ## Installation
 
-### Prerequisites
+### End Users
+
+Download the latest release from the [GitHub Releases](https://github.com/idaholab/ResDEEDS/releases) page:
+
+- **macOS**: Download the `.dmg` file
+- **Windows**: Download the `.exe` file
+
+#### Installing on macOS
+
+Due to the app not being notarized by Apple, you may see a security warning when opening the DMG file. To install:
+
+1. Download the `.dmg` file from the releases page
+2. Double-click the DMG file to mount it
+3. If you see a security warning, **right-click** on the ResDEEDS app and select **"Open"**
+4. Click **"Open"** again in the confirmation dialog
+5. Drag the ResDEEDS app to your Applications folder
+
+Alternatively, you can bypass Gatekeeper by running this command in Terminal:
+```bash
+sudo xattr -rd com.apple.quarantine /path/to/ResDEEDS.app
+```
+
+### Developers
+
+#### Prerequisites
 - Node.js (v18 or higher)
 - pnpm package manager
 
-### Setup
+#### Setup
 ```bash
 # Install dependencies
 pnpm install

--- a/build/entitlements.mac.plist
+++ b/build/entitlements.mac.plist
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <dict>
+    <!-- Allow execution of JIT-compiled code -->
+    <key>com.apple.security.cs.allow-jit</key>
+    <true/>
+    
+    <!-- Allow unsigned executable memory -->
+    <key>com.apple.security.cs.allow-unsigned-executable-memory</key>
+    <true/>
+    
+    <!-- Allow DYLD environment variables -->
+    <key>com.apple.security.cs.allow-dyld-environment-variables</key>
+    <true/>
+    
+    <!-- Disable library validation -->
+    <key>com.apple.security.cs.disable-library-validation</key>
+    <true/>
+    
+    <!-- Network client access -->
+    <key>com.apple.security.network.client</key>
+    <true/>
+    
+    <!-- File system access -->
+    <key>com.apple.security.files.user-selected.read-write</key>
+    <true/>
+    
+    <!-- Downloads folder access -->
+    <key>com.apple.security.files.downloads.read-write</key>
+    <true/>
+    
+    <!-- Documents folder access -->
+    <key>com.apple.security.files.bookmarks.app-scope</key>
+    <true/>
+    
+    <!-- Camera access (if needed for future features) -->
+    <key>com.apple.security.device.camera</key>
+    <true/>
+    
+    <!-- Microphone access (if needed for future features) -->
+    <key>com.apple.security.device.microphone</key>
+    <true/>
+  </dict>
+</plist>

--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -23,6 +23,8 @@ nsis:
   createDesktopShortcut: always
 mac:
   entitlementsInherit: build/entitlements.mac.plist
+  hardenedRuntime: true
+  gatekeeperAssess: false
   extendInfo:
     - NSCameraUsageDescription: Application requests access to the device's camera.
     - NSMicrophoneUsageDescription: Application requests access to the device's microphone.

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -12,6 +12,7 @@ module.exports = tseslint.config(
       'dist/**',
       '*.min.js',
       'coverage/**',
+      'ai_docs/**',
     ],
   },
   eslint.configs.recommended,


### PR DESCRIPTION
This pull request introduces improvements to the installation instructions for end users and developers, enhances macOS security and permissions for the desktop app, and updates configuration files to support these changes. The most important changes are grouped below by theme.

**Installation and Documentation Updates:**

* Expanded the `README.md` with clear installation instructions for end users on both macOS and Windows, including steps to bypass macOS Gatekeeper and a new section for developer setup.

**macOS App Security and Packaging:**

* Added a new entitlements file `build/entitlements.mac.plist` to specify required macOS permissions, such as JIT execution, file system access, camera/microphone access, and more.
* Updated `electron-builder.yml` to enable macOS hardened runtime, disable Gatekeeper assessment, and reference the new entitlements file for inherited permissions.

**Linting and Build Configuration:**

* Updated `eslint.config.js` to exclude the `ai_docs/**` directory from linting, improving build efficiency.